### PR TITLE
Make serialized `Insertion`s smaller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Changed
+
+- the `Serialize` impl of `Insertion` now produces 3-4x smaller payloads,
+  depending on the data format used ([#5](https://github.com/nomad/cola/pull/5));
+
 ## [0.3.0] - Jan 9 2024
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ sha2 = { version = "0.10", optional = true }
 criterion = "0.5"
 rand = "0.8"
 rand_chacha = "0.3"
+serde_json = "1"
 traces = { path = "./traces" }
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ rand = "0.8"
 rand_chacha = "0.3"
 serde_json = "1"
 traces = { path = "./traces" }
+zstd = "0.13"
 
 [[bench]]
 name = "traces"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 sha2 = { version = "0.10", optional = true }
 
 [dev-dependencies]
+bincode = "1.3"
 criterion = "0.5"
 rand = "0.8"
 rand_chacha = "0.3"

--- a/src/anchor.rs
+++ b/src/anchor.rs
@@ -102,6 +102,12 @@ impl core::fmt::Debug for InnerAnchor {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         if self == &Self::zero() {
             write!(f, "zero")
+        } else if f.alternate() {
+            write!(
+                f,
+                "{:x}.{} in {}",
+                self.replica_id, self.offset, self.contained_in
+            )
         } else {
             write!(f, "{:x}.{}", self.replica_id, self.offset)
         }

--- a/src/anchor.rs
+++ b/src/anchor.rs
@@ -148,7 +148,7 @@ impl InnerAnchor {
 #[cfg(feature = "encode")]
 mod encode {
     use super::*;
-    use crate::{Decode, Encode, Int};
+    use crate::encode::{Decode, Encode, Int, IntDecodeError};
 
     impl Encode for InnerAnchor {
         #[inline]
@@ -162,7 +162,7 @@ mod encode {
     impl Decode for InnerAnchor {
         type Value = Self;
 
-        type Error = core::convert::Infallible;
+        type Error = IntDecodeError;
 
         #[inline]
         fn decode(buf: &[u8]) -> Result<(Self, &[u8]), Self::Error> {

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -13,3 +13,71 @@ pub(crate) trait Decode: Sized {
     /// TODO: docs
     fn decode(buf: &[u8]) -> Result<(Self, &[u8]), Self::Error>;
 }
+
+pub(crate) use serde::{impl_deserialize, impl_serialize};
+
+#[cfg(feature = "serde")]
+mod serde {
+    macro_rules! impl_deserialize {
+        ($ty:ty) => {
+            impl<'de> ::serde::de::Deserialize<'de> for $ty {
+                #[inline]
+                fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+                where
+                    D: ::serde::de::Deserializer<'de>,
+                {
+                    struct Visitor;
+
+                    impl<'de> ::serde::de::Visitor<'de> for Visitor {
+                        type Value = $ty;
+
+                        #[inline]
+                        fn expecting(
+                            &self,
+                            formatter: &mut ::core::fmt::Formatter,
+                        ) -> ::core::fmt::Result {
+                            formatter.write_str("a byte slice")
+                        }
+
+                        #[inline]
+                        fn visit_bytes<E>(
+                            self,
+                            v: &[u8],
+                        ) -> Result<Self::Value, E>
+                        where
+                            E: ::serde::de::Error,
+                        {
+                            <Self::Value as $crate::Decode>::decode(v)
+                                .map(|(value, _rest)| value)
+                                .map_err(E::custom)
+                        }
+                    }
+
+                    deserializer.deserialize_bytes(Visitor)
+                }
+            }
+        };
+    }
+
+    macro_rules! impl_serialize {
+        ($ty:ty) => {
+            impl ::serde::ser::Serialize for $ty {
+                #[inline]
+                fn serialize<S>(
+                    &self,
+                    serializer: S,
+                ) -> Result<S::Ok, S::Error>
+                where
+                    S: ::serde::ser::Serializer,
+                {
+                    let mut buf = Vec::new();
+                    <Self as $crate::Encode>::encode(&self, &mut buf);
+                    serializer.serialize_bytes(&buf)
+                }
+            }
+        };
+    }
+
+    pub(crate) use impl_deserialize;
+    pub(crate) use impl_serialize;
+}

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -17,6 +17,43 @@ pub(crate) trait Decode {
 }
 
 /// A variable-length encoded integer.
+///
+/// This is a newtype around integers that can be `Encode`d using a variable
+/// number of bytes based on their value. When encoding, we:
+///
+/// - turn the integer into the corresponding little-endian byte array. The
+///   resulting array will have a fixed length equal to `mem::size_of::<I>`;
+///
+/// - ignore any trailing zeroes in the resulting byte array;
+///
+/// - push the length of the resulting byte slice;
+///
+/// - push the byte slice;
+///
+/// For example, `256u64` gets encoded as `[2, 0, 1]`.
+///
+/// With this scheme we could potentially encode integers up to
+/// `2 ^ (255 * 8) - 1`, which is ridiculously overkill for our use case since
+/// we only need to encode integers up to `u64::MAX`.
+///
+/// Because of this, we actually use the first byte to encode the integer
+/// itself if it's either 0 or between 9 and 255. We don't do this for 1..=8
+/// because we need to reserve those to represent the number of bytes that
+/// follow.
+///
+/// A few examples:
+///
+/// - `0` is encoded as `[0]`;
+///
+/// - `1` is encoded as `[1, 1]`;
+///
+/// - `8` is encoded as `[1, 8]`;
+///
+/// - `9` is encoded as `[9]`;
+///
+/// - `255` is encoded as `[255]`;
+///
+/// - numbers greater than 255 are always encoded as `[length, ..bytes..]`.
 pub(crate) struct Int<I>(I);
 
 impl<I> Int<I> {

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -1,0 +1,15 @@
+use std::error::Error as StdError;
+
+/// TODO: docs
+pub(crate) trait Encode {
+    /// TODO: docs
+    fn encode(&self, buf: &mut Vec<u8>);
+}
+
+/// TODO: docs
+pub(crate) trait Decode: Sized {
+    type Error: StdError;
+
+    /// TODO: docs
+    fn decode(buf: &[u8]) -> Result<(Self, &[u8]), Self::Error>;
+}

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -78,7 +78,7 @@ impl Decode for Int<usize> {
 
     type Error = IntDecodeError;
 
-    #[inline]
+    #[inline(always)]
     fn decode(buf: &[u8]) -> Result<(usize, &[u8]), Self::Error> {
         Int::<u64>::decode(buf).map(|(value, rest)| (value as usize, rest))
     }

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -233,6 +233,27 @@ mod serde {
                                 .map(|(value, _rest)| value)
                                 .map_err(E::custom)
                         }
+
+                        #[inline]
+                        fn visit_seq<A>(
+                            self,
+                            mut seq: A,
+                        ) -> Result<Self::Value, A::Error>
+                        where
+                            A: ::serde::de::SeqAccess<'de>,
+                        {
+                            let size = seq.size_hint().unwrap_or(0);
+                            let mut buf =
+                                ::alloc::vec::Vec::<u8>::with_capacity(size);
+                            while let Some(byte) = seq.next_element()? {
+                                buf.push(byte);
+                            }
+                            <Self::Value as $crate::encode::Decode>::decode(
+                                &buf,
+                            )
+                            .map(|(value, _rest)| value)
+                            .map_err(<A::Error as ::serde::de::Error>::custom)
+                        }
                     }
 
                     deserializer.deserialize_bytes(Visitor)

--- a/src/insertion.rs
+++ b/src/insertion.rs
@@ -179,7 +179,7 @@ mod encode {
             let (lamport_ts, buf) = Int::<LamportTs>::decode(buf)?;
             let (run, buf) = InsertionRun::decode(buf)?;
             let (anchor, buf) = Self::decode_anchor(run, &text, run_ts, buf)?;
-            let insertion = Self::new(anchor, text, run_ts, lamport_ts);
+            let insertion = Self::new(anchor, text, lamport_ts, run_ts);
             Ok((insertion, buf))
         }
     }
@@ -312,4 +312,28 @@ mod encode {
 mod serde {
     crate::impl_deserialize!(super::Insertion);
     crate::impl_serialize!(super::Insertion);
+}
+
+#[cfg(all(test, feature = "encode"))]
+mod encode_tests {
+    use super::*;
+    use crate::encode::{Decode, Encode};
+
+    impl core::fmt::Debug for encode::InsertionDecodeError {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            core::fmt::Display::fmt(self, f)
+        }
+    }
+
+    #[test]
+    fn encode_insertion_round_trip_0() {
+        let anchor = Anchor::new(1, 1, 1);
+        let text = Text::new(2, 0..1);
+        let insertion = Insertion::new(anchor, text, 3, 0);
+        let mut buf = Vec::new();
+        insertion.encode(&mut buf);
+        let (decoded, rest) = Insertion::decode(&buf).unwrap();
+        assert_eq!(insertion, decoded);
+        assert!(rest.is_empty());
+    }
 }

--- a/src/insertion.rs
+++ b/src/insertion.rs
@@ -91,7 +91,7 @@ impl Insertion {
 #[cfg(feature = "encode")]
 mod encode {
     use super::*;
-    use crate::{Decode, Encode, Int};
+    use crate::encode::{Decode, Encode, Int, IntDecodeError};
 
     impl Insertion {
         #[inline]
@@ -136,14 +136,14 @@ mod encode {
     impl Decode for Insertion {
         type Value = Self;
 
-        type Error = core::convert::Infallible;
+        type Error = IntDecodeError;
 
         #[inline]
         fn decode(buf: &[u8]) -> Result<(Self, &[u8]), Self::Error> {
             let (text, buf) = Text::decode(buf)?;
             let (run_ts, buf) = Int::<RunTs>::decode(buf)?;
             let (lamport_ts, buf) = Int::<LamportTs>::decode(buf)?;
-            let (run, buf) = InsertionRun::decode(buf)?;
+            let (run, buf) = InsertionRun::decode(buf).unwrap();
             let (anchor, buf) = Self::decode_anchor(run, &text, run_ts, buf)?;
             let insertion = Self::new(anchor, text, run_ts, lamport_ts);
             Ok((insertion, buf))

--- a/src/insertion.rs
+++ b/src/insertion.rs
@@ -310,8 +310,8 @@ mod encode {
 
 #[cfg(feature = "serde")]
 mod serde {
-    crate::impl_deserialize!(super::Insertion);
-    crate::impl_serialize!(super::Insertion);
+    crate::encode::impl_deserialize!(super::Insertion);
+    crate::encode::impl_serialize!(super::Insertion);
 }
 
 #[cfg(all(test, feature = "encode"))]

--- a/src/insertion.rs
+++ b/src/insertion.rs
@@ -196,9 +196,20 @@ mod encode {
     impl InsertionRun {
         #[inline]
         fn new(insertion: &Insertion) -> Self {
+            // To determine whether this insertion is a continuation of an
+            // existing insertion run we simply check:
+            //
+            // 1: the `ReplicaId`s of the anchor and the text. Clearly they
+            //    must match because you can't continue someone else's
+            //    insertion;
+            //
+            // 2: the `RunTs` of the anchor and the insertion. Since that
+            //    counter is only incremented when a new insertion run begins,
+            //    we know that if they match then this insertion must continue
+            //    an existing run.
             let is_continuation = insertion.anchor.replica_id()
                 == insertion.text.inserted_by()
-                && insertion.anchor.offset() == insertion.text.start();
+                && insertion.anchor.run_ts() == insertion.run_ts();
 
             if is_continuation {
                 Self::ContinuesExisting

--- a/src/insertion.rs
+++ b/src/insertion.rs
@@ -3,12 +3,15 @@ use crate::{LamportTs, Length, ReplicaId, RunTs, Text};
 
 /// An insertion in CRDT coordinates.
 ///
-/// This struct is created by the [`inserted`](Replica::inserted) method on the
-/// [`Replica`] owned by the peer that performed the insertion, and can be
-/// integrated by another [`Replica`] via the
-/// [`integrate_insertion`](Replica::integrate_insertion) method.
+/// This struct is created by the [`inserted`] method on the [`Replica`] owned
+/// by the peer that performed the insertion, and can be integrated by another
+/// [`Replica`] via the [`integrate_insertion`] method.
 ///
 /// See the documentation of those methods for more information.
+///
+/// [`Replica`]: crate::Replica
+/// [`inserted`]: crate::Replica::inserted
+/// [`integrate_insertion`]: crate::Replica::integrate_insertion
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Insertion {
     /// The anchor point of the insertion.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,8 +148,6 @@ pub use anchor::{Anchor, AnchorBias};
 use backlog::Backlog;
 pub use backlog::{BackloggedDeletions, BackloggedInsertions};
 pub use deletion::Deletion;
-#[cfg(feature = "serde")]
-use encode::{impl_deserialize, impl_serialize};
 #[cfg(feature = "encode")]
 use encoded_replica::{checksum, checksum_array};
 #[cfg(feature = "encode")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,8 +151,6 @@ pub use deletion::Deletion;
 #[cfg(feature = "serde")]
 use encode::{impl_deserialize, impl_serialize};
 #[cfg(feature = "encode")]
-use encode::{Decode, Encode, Int};
-#[cfg(feature = "encode")]
 use encoded_replica::{checksum, checksum_array};
 #[cfg(feature = "encode")]
 pub use encoded_replica::{DecodeError, EncodedReplica};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,8 @@ pub use anchor::{Anchor, AnchorBias};
 use backlog::Backlog;
 pub use backlog::{BackloggedDeletions, BackloggedInsertions};
 pub use deletion::Deletion;
+#[cfg(feature = "serde")]
+use encode::{impl_deserialize, impl_serialize};
 #[cfg(feature = "encode")]
 use encode::{Decode, Encode};
 #[cfg(feature = "encode")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,10 @@ extern crate alloc;
 mod anchor;
 mod backlog;
 mod deletion;
+#[cfg(feature = "encode")]
+mod encode;
+#[cfg(feature = "encode")]
+mod encoded_replica;
 mod gtree;
 mod insertion;
 mod replica;
@@ -144,6 +148,12 @@ pub use anchor::{Anchor, AnchorBias};
 use backlog::Backlog;
 pub use backlog::{BackloggedDeletions, BackloggedInsertions};
 pub use deletion::Deletion;
+#[cfg(feature = "encode")]
+use encode::{Decode, Encode};
+#[cfg(feature = "encode")]
+use encoded_replica::{checksum, checksum_array};
+#[cfg(feature = "encode")]
+pub use encoded_replica::{DecodeError, EncodedReplica};
 use gtree::{Gtree, LeafIdx};
 pub use insertion::Insertion;
 pub use replica::Replica;
@@ -155,13 +165,6 @@ use run_tree::*;
 pub use text::Text;
 use utils::*;
 use version_map::{DeletionMap, VersionMap};
-
-#[cfg(feature = "encode")]
-mod encoded_replica;
-#[cfg(feature = "encode")]
-use encoded_replica::{checksum, checksum_array};
-#[cfg(feature = "encode")]
-pub use encoded_replica::{DecodeError, EncodedReplica};
 
 /// The version of the protocol cola uses to represent `EncodedReplica`s and
 /// `CrdtEdit`s.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,7 @@ pub use deletion::Deletion;
 #[cfg(feature = "serde")]
 use encode::{impl_deserialize, impl_serialize};
 #[cfg(feature = "encode")]
-use encode::{Decode, Encode};
+use encode::{Decode, Encode, Int};
 #[cfg(feature = "encode")]
 use encoded_replica::{checksum, checksum_array};
 #[cfg(feature = "encode")]

--- a/src/text.rs
+++ b/src/text.rs
@@ -113,7 +113,7 @@ impl Text {
 #[cfg(feature = "encode")]
 mod encode {
     use super::*;
-    use crate::{Decode, Encode, Int};
+    use crate::encode::{Decode, Encode, Int, IntDecodeError};
 
     impl Encode for Text {
         #[inline]
@@ -128,7 +128,7 @@ mod encode {
     impl Decode for Text {
         type Value = Self;
 
-        type Error = core::convert::Infallible;
+        type Error = IntDecodeError;
 
         #[inline]
         fn decode(buf: &[u8]) -> Result<(Self, &[u8]), Self::Error> {

--- a/src/text.rs
+++ b/src/text.rs
@@ -120,6 +120,12 @@ mod encode {
         fn encode(&self, buf: &mut Vec<u8>) {
             Int::new(self.inserted_by).encode(buf);
             Int::new(self.start()).encode(buf);
+            // We encode the length of the text because it's often smaller than
+            // its end, especially for longer editing sessions.
+            //
+            // For example, if a user inserts a character after already having
+            // inserted 1000 before, it's better to encode `1000, 1` rather
+            // than `1000, 1001`.
             let len = self.end() - self.start();
             Int::new(len).encode(buf);
         }

--- a/src/text.rs
+++ b/src/text.rs
@@ -10,7 +10,6 @@ use crate::*;
 /// [`inserted_by`](Text::inserted_by) and
 /// [`temporal_range`](Text::temporal_range) methods respectively.
 #[derive(Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "encode", derive(serde::Serialize, serde::Deserialize))]
 pub struct Text {
     pub(crate) inserted_by: ReplicaId,
     pub(crate) range: Range<Length>,
@@ -145,4 +144,10 @@ mod encode {
             Ok((text, buf))
         }
     }
+}
+
+#[cfg(feature = "serde")]
+mod serde {
+    crate::encode::impl_deserialize!(super::Text);
+    crate::encode::impl_serialize!(super::Text);
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -38,7 +38,7 @@ impl PartialEq<Replica> for &str {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Edit {
     Insertion(cola::Insertion, String),

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -39,6 +39,7 @@ impl PartialEq<Replica> for &str {
 }
 
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Edit {
     Insertion(cola::Insertion, String),
     Deletion(cola::Deletion),

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -2,6 +2,7 @@
 mod encode {
     use cola::Replica;
 
+    /// Tests an encode-decode round-trip of an empty `Replica`.
     #[test]
     fn encode_empty() {
         let replica = Replica::new(1, 42);
@@ -10,16 +11,17 @@ mod encode {
         assert!(replica.eq_decoded(&decoded));
     }
 
+    /// Tests an encode-decode round-trip of a `Replica` that has gone through
+    /// the `automerge` trace.
     #[test]
-    #[allow(unused_must_use)]
     fn encode_automerge() {
         let automerge = traces::automerge().chars_to_bytes();
 
         let mut replica = Replica::new(1, automerge.start_content().len());
 
         for (start, end, text) in automerge.edits() {
-            replica.deleted(start..end);
-            replica.inserted(start, text.len());
+            let _ = replica.deleted(start..end);
+            let _ = replica.inserted(start, text.len());
         }
 
         let encoded = replica.encode();

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,0 +1,67 @@
+mod common;
+
+#[cfg(feature = "serde")]
+mod serde {
+    use traces::{ConcurrentTraceInfos, Crdt, Edit};
+
+    use super::common::{self, Replica};
+
+    type Encode = fn(&common::Edit) -> Vec<u8>;
+
+    type Decode = fn(Vec<u8>) -> common::Edit;
+
+    fn test_trace<const N: usize>(
+        trace: ConcurrentTraceInfos<N, Replica>,
+        encode: Encode,
+        decode: Decode,
+    ) {
+        let ConcurrentTraceInfos { trace, mut peers, final_content, .. } =
+            trace;
+
+        for edit in trace.edits() {
+            match edit {
+                Edit::Insertion(idx, offset, text) => {
+                    peers[*idx].local_insert(*offset, text);
+                    peers[*idx].assert_invariants();
+                },
+                Edit::Deletion(idx, start, end) => {
+                    peers[*idx].local_delete(*start, *end);
+                    peers[*idx].assert_invariants();
+                },
+                Edit::Merge(idx, edit) => {
+                    let encoded = encode(edit);
+                    let decoded = decode(encoded);
+                    peers[*idx].remote_merge(&decoded);
+                    peers[*idx].assert_invariants();
+                },
+            }
+        }
+
+        for replica in &mut peers {
+            replica.merge_backlogged();
+        }
+
+        for replica in &peers {
+            assert_eq!(replica.buffer, final_content);
+        }
+    }
+
+    /// Tests that the `friends-forever` trace converges if we serialize and
+    /// deserialize every edit before applying it.
+    #[test]
+    fn serde_friends_forever_round_trip() {
+        test_trace(
+            traces::friends_forever(),
+            serde_json_encode,
+            serde_json_decode,
+        );
+    }
+
+    fn serde_json_encode(edit: &common::Edit) -> Vec<u8> {
+        serde_json::to_vec(edit).unwrap()
+    }
+
+    fn serde_json_decode(buf: Vec<u8>) -> common::Edit {
+        serde_json::from_slice(&buf).unwrap()
+    }
+}


### PR DESCRIPTION
Introduces two new internal traits, `Encode` and `Decode`, that we can use to implement more efficient encoding schemes for `Replica`s, `Insertion`s, `Deletion`s and `Anchor`s.

In this PR I've only refactored the encoding of the `Insertion` type, which now produces ~3-4x smaller payloads. Of course, the exact factor depends on the serde data format used.

For example, serializing every `Insertion` produced by running the `automerge` trace results in:

```sh
# Before
serde_json | Total insertions: 27.06 MB
bincode | Total insertions: 11.13 MB
```

```sh
# After
serde_json | Total insertions: 6.62 MB
bincode | Total insertions: 3.96 MB
```