### PR TITLE
Make serialized `Replica`s smaller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Changed
 
+- the `Serialize` impl of `EncodedReplica` now produces ~7x smaller payloads,
+  depending on the data format used
+  ([#6](https://github.com/nomad/cola/pull/6));
+
 - the `Serialize` impl of `Insertion` now produces 3-4x smaller payloads,
   depending on the data format used ([#5](https://github.com/nomad/cola/pull/5));
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,11 @@ exclude = ["/.github/*", "/examples/**", "/fuzz/**", "/tests/**"]
 features = ["serde"]
 rustdoc-args = ["--cfg", "docsrs"]
 
-[lib]
-name = "cola"
-
 [features]
-encode = ["dep:bincode", "dep:sha2", "dep:serde"]
+encode = ["dep:sha2"]
 serde = ["encode", "dep:serde"]
 
 [dependencies]
-bincode = { version = "1.3", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 sha2 = { version = "0.10", optional = true }
 

--- a/src/anchor.rs
+++ b/src/anchor.rs
@@ -154,14 +154,14 @@ impl InnerAnchor {
 #[cfg(feature = "encode")]
 mod encode {
     use super::*;
-    use crate::encode::{Decode, Encode, Int, IntDecodeError};
+    use crate::encode::{Decode, Encode, IntDecodeError};
 
     impl Encode for InnerAnchor {
         #[inline]
         fn encode(&self, buf: &mut Vec<u8>) {
-            Int::new(self.replica_id()).encode(buf);
-            Int::new(self.run_ts()).encode(buf);
-            Int::new(self.offset()).encode(buf);
+            self.replica_id().encode(buf);
+            self.run_ts().encode(buf);
+            self.offset().encode(buf);
         }
     }
 
@@ -172,9 +172,9 @@ mod encode {
 
         #[inline]
         fn decode(buf: &[u8]) -> Result<(Self, &[u8]), Self::Error> {
-            let (replica_id, buf) = Int::<ReplicaId>::decode(buf)?;
-            let (run_ts, buf) = Int::<RunTs>::decode(buf)?;
-            let (offset, buf) = Int::<Length>::decode(buf)?;
+            let (replica_id, buf) = ReplicaId::decode(buf)?;
+            let (run_ts, buf) = RunTs::decode(buf)?;
+            let (offset, buf) = Length::decode(buf)?;
             let anchor = Self::new(replica_id, offset, run_ts);
             Ok((anchor, buf))
         }

--- a/src/backlog.rs
+++ b/src/backlog.rs
@@ -8,7 +8,6 @@ use crate::*;
 ///
 /// See [`Replica::backlogged`] for more information.
 #[derive(Debug, Clone, Default, PartialEq)]
-#[cfg_attr(feature = "encode", derive(serde::Serialize, serde::Deserialize))]
 pub(crate) struct Backlog {
     insertions: ReplicaIdMap<InsertionsBacklog>,
     deletions: ReplicaIdMap<DeletionsBacklog>,
@@ -69,7 +68,6 @@ impl Backlog {
 
 /// Stores the backlogged [`Insertion`]s of a particular replica.
 #[derive(Clone, Default, PartialEq)]
-#[cfg_attr(feature = "encode", derive(serde::Serialize, serde::Deserialize))]
 struct InsertionsBacklog {
     insertions: VecDeque<Insertion>,
 }
@@ -115,7 +113,6 @@ impl InsertionsBacklog {
 
 /// Stores the backlogged [`Deletion`]s of a particular replica.
 #[derive(Clone, Default, PartialEq)]
-#[cfg_attr(feature = "encode", derive(serde::Serialize, serde::Deserialize))]
 struct DeletionsBacklog {
     deletions: VecDeque<Deletion>,
 }
@@ -548,4 +545,10 @@ mod encode {
             Ok(((), buf))
         }
     }
+}
+
+#[cfg(feature = "serde")]
+mod serde {
+    crate::encode::impl_serialize!(super::Backlog);
+    crate::encode::impl_deserialize!(super::Backlog);
 }

--- a/src/backlog.rs
+++ b/src/backlog.rs
@@ -281,7 +281,7 @@ impl Iterator for BackloggedInsertions<'_> {
 impl core::iter::FusedIterator for BackloggedInsertions<'_> {}
 
 #[cfg(feature = "encode")]
-mod encode {
+pub(crate) mod encode {
     use super::*;
     use crate::encode::{Decode, DecodeWithCtx, Encode, IntDecodeError};
     use crate::version_map::encode::BaseMapDecodeError;

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -27,7 +27,7 @@ pub(crate) trait DecodeWithCtx {
     /// TODO: docs
     fn decode<'buf>(
         buf: &'buf [u8],
-        ctx: &Self::Ctx,
+        ctx: &mut Self::Ctx,
     ) -> Result<(Self::Value, &'buf [u8]), Self::Error>;
 }
 

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -16,6 +16,21 @@ pub(crate) trait Decode {
     fn decode(buf: &[u8]) -> Result<(Self::Value, &[u8]), Self::Error>;
 }
 
+/// TODO: docs
+pub(crate) trait DecodeWithCtx {
+    type Value: Sized;
+
+    type Error: Display;
+
+    type Ctx;
+
+    /// TODO: docs
+    fn decode<'buf>(
+        buf: &'buf [u8],
+        ctx: &Self::Ctx,
+    ) -> Result<(Self::Value, &'buf [u8]), Self::Error>;
+}
+
 impl Encode for bool {
     #[inline]
     fn encode(&self, buf: &mut Vec<u8>) {

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -117,14 +117,8 @@ impl core::fmt::Display for BoolDecodeError {
 /// - `255` is encoded as `[255]`;
 ///
 /// - numbers greater than 255 are always encoded as `[length, ..bytes..]`.
-pub(crate) struct Int<I>(I);
-
-impl<I> Int<I> {
-    #[inline]
-    pub(crate) fn new(integer: I) -> Self {
-        Self(integer)
-    }
-}
+#[allow(dead_code)]
+struct Int<I>(I);
 
 /// An error that can occur when decoding an [`Int`].
 #[cfg_attr(test, derive(PartialEq, Eq))]
@@ -166,30 +160,30 @@ impl_int_decode!(u16);
 impl_int_decode!(u32);
 impl_int_decode!(u64);
 
-impl Encode for Int<usize> {
+impl Encode for usize {
     #[inline(always)]
     fn encode(&self, buf: &mut Vec<u8>) {
-        Int(self.0 as u64).encode(buf)
+        (*self as u64).encode(buf)
     }
 }
 
-impl Decode for Int<usize> {
+impl Decode for usize {
     type Value = usize;
 
     type Error = IntDecodeError;
 
     #[inline(always)]
     fn decode(buf: &[u8]) -> Result<(usize, &[u8]), Self::Error> {
-        Int::<u64>::decode(buf).map(|(value, rest)| (value as usize, rest))
+        u64::decode(buf).map(|(value, rest)| (value as usize, rest))
     }
 }
 
 macro_rules! impl_int_encode {
     ($ty:ty) => {
-        impl Encode for Int<$ty> {
+        impl Encode for $ty {
             #[inline]
             fn encode(&self, buf: &mut Vec<u8>) {
-                let int = self.0;
+                let int = *self;
 
                 // We can encode the entire integer with a single byte if it
                 // falls within this range.
@@ -221,8 +215,8 @@ use impl_int_encode;
 
 macro_rules! impl_int_decode {
     ($ty:ty) => {
-        impl Decode for Int<$ty> {
-            type Value = $ty;
+        impl Decode for $ty {
+            type Value = Self;
 
             type Error = $crate::encode::IntDecodeError;
 
@@ -367,9 +361,9 @@ mod tests {
         let mut buf = Vec::new();
 
         for int in ints {
-            Int::new(int).encode(&mut buf);
+            int.encode(&mut buf);
             assert_eq!(buf.len(), 1);
-            let (decoded, rest) = Int::<u64>::decode(&buf).unwrap();
+            let (decoded, rest) = u64::decode(&buf).unwrap();
             assert_eq!(int, decoded);
             assert!(rest.is_empty());
             buf.clear();
@@ -398,7 +392,7 @@ mod tests {
         };
 
         for int in ints {
-            Int::new(int).encode(&mut buf);
+            int.encode(&mut buf);
 
             let expected_len = (1..=8)
                 .map(|n_bytes| (n_bytes, max_num_with_n_bytes(n_bytes)))
@@ -411,7 +405,7 @@ mod tests {
 
             assert_eq!(buf[1..].len() as u8, expected_len);
 
-            let (decoded, rest) = Int::<u64>::decode(&buf).unwrap();
+            let (decoded, rest) = u64::decode(&buf).unwrap();
 
             assert_eq!(int, decoded);
 
@@ -426,12 +420,12 @@ mod tests {
     fn encode_int_fails_if_buffer_empty() {
         let mut buf = Vec::new();
 
-        Int::new(42u32).encode(&mut buf);
+        42u32.encode(&mut buf);
 
         buf.clear();
 
         assert_eq!(
-            Int::<u32>::decode(&buf).unwrap_err(),
+            u32::decode(&buf).unwrap_err(),
             IntDecodeError::EmptyBuffer
         );
     }
@@ -442,12 +436,12 @@ mod tests {
     fn encode_int_fails_if_buffer_too_short() {
         let mut buf = Vec::new();
 
-        Int::new(u8::MAX as u16 + 1).encode(&mut buf);
+        (u8::MAX as u16 + 1).encode(&mut buf);
 
         buf.pop();
 
         assert_eq!(
-            Int::<u32>::decode(&buf).unwrap_err(),
+            u32::decode(&buf).unwrap_err(),
             IntDecodeError::LengthLessThanPrefix { prefix: 2, actual: 1 }
         );
     }

--- a/src/gtree.rs
+++ b/src/gtree.rs
@@ -2411,8 +2411,8 @@ struct Inode<const ARITY: usize, L: Leaf> {
     /// or equal to `ARITY`.
     num_children: usize,
 
-    /// The indexes of this node's children in the Gtree. The first `len` of
-    /// these are valid, and the rest are dangling.
+    /// The indexes of this node's children in the Gtree. The first
+    /// `num_children` are valid, while the rest are dangling.
     children: [NodeIdx<L>; ARITY],
 
     /// Whether `children` contains `LeafIdx<L>`s or `InodeIdx`s.

--- a/src/gtree.rs
+++ b/src/gtree.rs
@@ -99,7 +99,7 @@ const _NODE_IDX_LAYOUT_CHECK: usize = {
 /// which the internal and leaf nodes are stored in memory.
 ///
 /// TODO: finish describing the data structure.
-#[derive(Clone, PartialEq)]
+#[derive(Clone)]
 pub(crate) struct Gtree<const ARITY: usize, L: Leaf> {
     /// The internal nodes of the Gtree.
     ///
@@ -2391,6 +2391,29 @@ impl<const ARITY: usize, L: Leaf> Gtree<ARITY, L> {
             },
 
             _ => (None, None, None),
+        }
+    }
+}
+
+impl<const N: usize, const M: usize, L: Leaf> PartialEq<Gtree<M, L>>
+    for Gtree<N, L>
+where
+    L: PartialEq,
+{
+    #[inline]
+    fn eq(&self, other: &Gtree<M, L>) -> bool {
+        let mut this = self.leaves_from_first();
+        let mut other = other.leaves_from_first();
+        loop {
+            match (this.next(), other.next()) {
+                (None, None) => return true,
+                (Some((_, this)), Some((_, other))) => {
+                    if this != other {
+                        return false;
+                    }
+                },
+                _ => return false,
+            }
         }
     }
 }

--- a/src/gtree.rs
+++ b/src/gtree.rs
@@ -3527,6 +3527,25 @@ mod encode {
         }
     }
 
+    impl<L> Encode for NodeIdx<L> {
+        #[inline]
+        fn encode(&self, buf: &mut Vec<u8>) {
+            self.into_usize().encode(buf);
+        }
+    }
+
+    impl<L> Decode for NodeIdx<L> {
+        type Value = Self;
+
+        type Error = IntDecodeError;
+
+        #[inline]
+        fn decode(buf: &[u8]) -> Result<(Self, &[u8]), Self::Error> {
+            let (idx, rest) = usize::decode(buf)?;
+            Ok((Self::from_internal(InodeIdx(idx)), rest))
+        }
+    }
+
     impl<const N: usize, L: Leaf> Encode for Inode<N, L>
     where
         L::Length: Encode,

--- a/src/gtree.rs
+++ b/src/gtree.rs
@@ -518,6 +518,11 @@ impl<const ARITY: usize, L: Leaf> Gtree<ARITY, L> {
     }
 
     #[inline(always)]
+    pub fn num_leaves(&self) -> usize {
+        self.lnodes.len()
+    }
+
+    #[inline(always)]
     pub fn inodes(&self) -> &[Inode<ARITY, L>] {
         &self.inodes
     }

--- a/src/gtree.rs
+++ b/src/gtree.rs
@@ -96,7 +96,7 @@ const _NODE_IDX_LAYOUT_CHECK: usize = {
 ///
 /// TODO: finish describing the data structure.
 #[derive(Clone, PartialEq)]
-#[cfg_attr(feature = "encode", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "encode", derive(serde::Serialize, ::serde::Deserialize))]
 pub(crate) struct Gtree<const ARITY: usize, L: Leaf> {
     /// The internal nodes of the Gtree.
     ///
@@ -3500,12 +3500,12 @@ mod iter {
 #[cfg(feature = "encode")]
 mod encode {
     use super::*;
-    use crate::encode::{Decode, Encode, Int, IntDecodeError};
+    use crate::encode::{Decode, Encode, IntDecodeError};
 
     impl Encode for InodeIdx {
         #[inline]
         fn encode(&self, buf: &mut Vec<u8>) {
-            Int::new(self.0).encode(buf);
+            self.0.encode(buf);
         }
     }
 
@@ -3516,7 +3516,7 @@ mod encode {
 
         #[inline]
         fn decode(buf: &[u8]) -> Result<(Self, &[u8]), Self::Error> {
-            let (idx, rest) = Int::<usize>::decode(buf)?;
+            let (idx, rest) = usize::decode(buf)?;
             Ok((Self(idx), rest))
         }
     }
@@ -3524,7 +3524,7 @@ mod encode {
     impl<L> Encode for LeafIdx<L> {
         #[inline]
         fn encode(&self, buf: &mut Vec<u8>) {
-            Int::new(self.idx).encode(buf);
+            self.idx.encode(buf);
         }
     }
 
@@ -3535,12 +3535,15 @@ mod encode {
 
         #[inline]
         fn decode(buf: &[u8]) -> Result<(Self, &[u8]), Self::Error> {
-            let (idx, rest) = Int::<usize>::decode(buf)?;
+            let (idx, rest) = usize::decode(buf)?;
             Ok((Self::new(idx), rest))
         }
     }
 
-    impl<const N: usize, L: Leaf> Encode for Inode<N, L> {
+    impl<const N: usize, L: Leaf> Encode for Inode<N, L>
+    where
+        L::Length: Encode,
+    {
         #[inline]
         fn encode(&self, _buf: &mut Vec<u8>) {
             todo!();

--- a/src/gtree.rs
+++ b/src/gtree.rs
@@ -142,7 +142,7 @@ impl InodeIdx {
     ///
     /// 2. For the root node, to indicate that it has no parent.
     #[inline]
-    const fn dangling() -> Self {
+    pub(crate) const fn dangling() -> Self {
         Self(usize::MAX)
     }
 
@@ -182,8 +182,13 @@ impl<L> LeafIdx<L> {
     /// Returns a "dangling" index which doesn't point to any leaf of the
     /// Gtree.
     #[inline]
-    pub const fn dangling() -> Self {
+    pub(crate) const fn dangling() -> Self {
         Self::new(usize::MAX)
+    }
+
+    #[inline]
+    pub(crate) fn into_usize(self) -> usize {
+        self.idx
     }
 
     #[inline]

--- a/src/gtree.rs
+++ b/src/gtree.rs
@@ -2732,7 +2732,7 @@ impl<const ARITY: usize, L: Leaf> Inode<ARITY, L> {
 /// A leaf node of the Gtree.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "encode", derive(serde::Serialize, serde::Deserialize))]
-struct Lnode<Leaf> {
+pub(crate) struct Lnode<Leaf> {
     /// The value of this leaf node.
     value: Leaf,
 
@@ -2747,7 +2747,7 @@ impl<L: Leaf> Lnode<L> {
     }
 
     #[inline(always)]
-    fn new(value: L, parent: InodeIdx) -> Self {
+    pub(crate) fn new(value: L, parent: InodeIdx) -> Self {
         Self { value, parent }
     }
 

--- a/src/insertion.rs
+++ b/src/insertion.rs
@@ -94,13 +94,7 @@ impl Insertion {
 #[cfg(feature = "encode")]
 mod encode {
     use super::*;
-    use crate::encode::{
-        BoolDecodeError,
-        Decode,
-        Encode,
-        Int,
-        IntDecodeError,
-    };
+    use crate::encode::{BoolDecodeError, Decode, Encode, IntDecodeError};
 
     impl Insertion {
         #[inline]
@@ -134,8 +128,8 @@ mod encode {
         #[inline]
         fn encode(&self, buf: &mut Vec<u8>) {
             self.text.encode(buf);
-            Int::new(self.run_ts).encode(buf);
-            Int::new(self.lamport_ts).encode(buf);
+            self.run_ts.encode(buf);
+            self.lamport_ts.encode(buf);
             let run = InsertionRun::new(self);
             run.encode(buf);
             self.encode_anchor(run, buf);
@@ -181,8 +175,8 @@ mod encode {
         #[inline]
         fn decode(buf: &[u8]) -> Result<(Self, &[u8]), Self::Error> {
             let (text, buf) = Text::decode(buf)?;
-            let (run_ts, buf) = Int::<RunTs>::decode(buf)?;
-            let (lamport_ts, buf) = Int::<LamportTs>::decode(buf)?;
+            let (run_ts, buf) = RunTs::decode(buf)?;
+            let (lamport_ts, buf) = LamportTs::decode(buf)?;
             let (run, buf) = InsertionRun::decode(buf)?;
             let (anchor, buf) = Self::decode_anchor(run, &text, run_ts, buf)?;
             let insertion = Self::new(anchor, text, lamport_ts, run_ts);

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -880,8 +880,11 @@ impl Replica {
 
         let initial_text = Text::new(id, 0..len);
 
-        let first_run =
-            EditRun::new(initial_text, run_clock.next(), lamport_clock.next());
+        let first_run = EditRun::new_visible(
+            initial_text,
+            run_clock.next(),
+            lamport_clock.next(),
+        );
 
         let run_tree = RunTree::new(first_run);
 

--- a/src/run_indices.rs
+++ b/src/run_indices.rs
@@ -60,7 +60,8 @@ impl RunIndices {
     #[inline]
     pub(crate) fn iter(
         &self,
-    ) -> impl Iterator<Item = (&ReplicaId, &ReplicaIndices)> + '_ {
+    ) -> impl ExactSizeIterator<Item = (&ReplicaId, &ReplicaIndices)> + '_
+    {
         self.map.iter()
     }
 
@@ -774,7 +775,7 @@ impl Fragment {
     }
 
     #[inline]
-    fn new(len: Length, idx: LeafIdx<EditRun>) -> Self {
+    pub(crate) fn new(len: Length, idx: LeafIdx<EditRun>) -> Self {
         Self { idx, len }
     }
 

--- a/src/run_indices.rs
+++ b/src/run_indices.rs
@@ -429,6 +429,14 @@ mod fragments {
         }
 
         #[inline]
+        pub(crate) fn num_fragments(&self) -> usize {
+            match self {
+                Self::Array(array) => array.len,
+                Self::Gtree(gtree) => gtree.num_leaves(),
+            }
+        }
+
+        #[inline]
         pub fn split(&mut self, at_offset: Length, new_idx: LeafIdx<EditRun>) {
             match self {
                 Fragments::Array(array) => {

--- a/src/run_indices.rs
+++ b/src/run_indices.rs
@@ -465,10 +465,8 @@ mod fragments {
     impl<const N: usize> gtree::Join for Fragments<N> {}
 
     impl<const N: usize> gtree::Leaf for Fragments<N> {
-        type Length = Length;
-
         #[inline]
-        fn len(&self) -> Self::Length {
+        fn len(&self) -> Length {
             self.len()
         }
     }
@@ -808,10 +806,8 @@ impl Fragment {
 impl gtree::Join for Fragment {}
 
 impl gtree::Leaf for Fragment {
-    type Length = Length;
-
     #[inline]
-    fn len(&self) -> Self::Length {
+    fn len(&self) -> Length {
         self.len
     }
 }

--- a/src/run_indices.rs
+++ b/src/run_indices.rs
@@ -768,6 +768,11 @@ impl Fragment {
         *self == Self::null()
     }
 
+    #[inline(always)]
+    pub(crate) fn leaf_idx(&self) -> LeafIdx<EditRun> {
+        self.idx
+    }
+
     #[inline]
     fn new(len: Length, idx: LeafIdx<EditRun>) -> Self {
         Self { idx, len }

--- a/src/run_tree.rs
+++ b/src/run_tree.rs
@@ -1115,7 +1115,7 @@ pub(crate) type DebugAsSelf<'a> =
     gtree::DebugAsSelf<'a, RUN_TREE_ARITY, EditRun>;
 
 #[cfg(feature = "encode")]
-mod encode {
+pub(crate) mod encode {
     use core::mem;
 
     use super::*;

--- a/src/run_tree.rs
+++ b/src/run_tree.rs
@@ -1319,7 +1319,7 @@ mod encode {
     impl Encode for RunFragments<'_> {
         #[inline(always)]
         fn encode(&self, buf: &mut Vec<u8>) {
-            (self.fragments.len() as u64).encode(buf);
+            (self.fragments.num_fragments() as u64).encode(buf);
 
             for fragment in self.fragments.iter() {
                 RunFragment::new(fragment.leaf_idx(), self.gtree).encode(buf);

--- a/src/run_tree.rs
+++ b/src/run_tree.rs
@@ -10,7 +10,6 @@ const RUN_TREE_ARITY: usize = 32;
 type Gtree = crate::Gtree<RUN_TREE_ARITY, EditRun>;
 
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "encode", derive(serde::Serialize, serde::Deserialize))]
 pub(crate) struct RunTree {
     /// The tree of runs.
     gtree: Gtree,
@@ -844,7 +843,6 @@ impl RunTree {
 
 /// TODO: docs
 #[derive(Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "encode", derive(serde::Serialize, serde::Deserialize))]
 pub(crate) struct EditRun {
     /// TODO: docs
     text: Text,
@@ -1418,4 +1416,10 @@ mod encode {
             Ok(((), buf))
         }
     }
+}
+
+#[cfg(feature = "serde")]
+mod serde {
+    crate::encode::impl_serialize!(super::RunTree);
+    crate::encode::impl_deserialize!(super::RunTree);
 }

--- a/src/run_tree.rs
+++ b/src/run_tree.rs
@@ -1128,7 +1128,7 @@ mod encode {
         Encode,
         IntDecodeError,
     };
-    use crate::gtree::{Inode, InodeIdx, Lnode};
+    use crate::gtree::{encode::InodeDecodeError, Inode, InodeIdx, Lnode};
     use crate::run_indices::{Fragment, Fragments, ReplicaIndices};
 
     impl Encode for RunTree {
@@ -1156,6 +1156,7 @@ mod encode {
 
     pub(crate) enum RunTreeDecodeError {
         Bool(BoolDecodeError),
+        Inode(InodeDecodeError),
         Int(IntDecodeError),
     }
 
@@ -1163,6 +1164,13 @@ mod encode {
         #[inline(always)]
         fn from(err: BoolDecodeError) -> Self {
             Self::Bool(err)
+        }
+    }
+
+    impl From<InodeDecodeError> for RunTreeDecodeError {
+        #[inline(always)]
+        fn from(err: InodeDecodeError) -> Self {
+            Self::Inode(err)
         }
     }
 
@@ -1176,10 +1184,13 @@ mod encode {
     impl core::fmt::Display for RunTreeDecodeError {
         #[inline]
         fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-            match self {
-                Self::Bool(err) => err.fmt(f),
-                Self::Int(err) => err.fmt(f),
-            }
+            let err: &dyn core::fmt::Display = match self {
+                Self::Bool(err) => err,
+                Self::Inode(err) => err,
+                Self::Int(err) => err,
+            };
+
+            write!(f, "RunTree: couldn't be decoded: {err}")
         }
     }
 

--- a/src/run_tree.rs
+++ b/src/run_tree.rs
@@ -1074,38 +1074,6 @@ impl EditRun {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum Diff {
-    Add(Length),
-    Subtract(Length),
-}
-
-impl gtree::Length for Length {
-    type Diff = Diff;
-
-    #[inline]
-    fn zero() -> Self {
-        0
-    }
-
-    #[inline]
-    fn diff(from: Self, to: Self) -> Diff {
-        if from < to {
-            Diff::Add(to - from)
-        } else {
-            Diff::Subtract(from - to)
-        }
-    }
-
-    #[inline]
-    fn apply_diff(&mut self, diff: Diff) {
-        match diff {
-            Diff::Add(add) => *self += add,
-            Diff::Subtract(sub) => *self -= sub,
-        }
-    }
-}
-
 impl gtree::Join for EditRun {
     #[inline]
     fn append(&mut self, other: Self) -> Result<(), Self> {
@@ -1136,10 +1104,8 @@ impl gtree::Delete for EditRun {
 }
 
 impl gtree::Leaf for EditRun {
-    type Length = Length;
-
     #[inline]
-    fn len(&self) -> Self::Length {
+    fn len(&self) -> Length {
         self.visible_len()
     }
 }

--- a/src/text.rs
+++ b/src/text.rs
@@ -112,13 +112,13 @@ impl Text {
 #[cfg(feature = "encode")]
 mod encode {
     use super::*;
-    use crate::encode::{Decode, Encode, Int, IntDecodeError};
+    use crate::encode::{Decode, Encode, IntDecodeError};
 
     impl Encode for Text {
         #[inline]
         fn encode(&self, buf: &mut Vec<u8>) {
-            Int::new(self.inserted_by).encode(buf);
-            Int::new(self.start()).encode(buf);
+            self.inserted_by.encode(buf);
+            self.start().encode(buf);
             // We encode the length of the text because it's often smaller than
             // its end, especially for longer editing sessions.
             //
@@ -126,7 +126,7 @@ mod encode {
             // inserted 1000 before, it's better to encode `1000, 1` rather
             // than `1000, 1001`.
             let len = self.end() - self.start();
-            Int::new(len).encode(buf);
+            len.encode(buf);
         }
     }
 
@@ -137,9 +137,9 @@ mod encode {
 
         #[inline]
         fn decode(buf: &[u8]) -> Result<(Self, &[u8]), Self::Error> {
-            let (inserted_by, buf) = Int::<ReplicaId>::decode(buf)?;
-            let (start, buf) = Int::<usize>::decode(buf)?;
-            let (len, buf) = Int::<usize>::decode(buf)?;
+            let (inserted_by, buf) = ReplicaId::decode(buf)?;
+            let (start, buf) = usize::decode(buf)?;
+            let (len, buf) = usize::decode(buf)?;
             let text = Self { inserted_by, range: start..start + len };
             Ok((text, buf))
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,6 @@ use core::ops::{Add, Range as StdRange, RangeBounds, Sub};
 use crate::Length;
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "encode", derive(serde::Serialize, serde::Deserialize))]
 pub(crate) struct Range<T> {
     pub start: T,
     pub end: T,

--- a/src/version_map.rs
+++ b/src/version_map.rs
@@ -153,7 +153,7 @@ impl PartialOrd for VersionMap {
 }
 
 #[cfg(feature = "encode")]
-mod encode {
+pub(crate) mod encode {
     use super::*;
     use crate::encode::{Decode, Encode, IntDecodeError};
 


### PR DESCRIPTION
This follows the previous PR (#5), now for `Replica`s.

```py
# Before
serde_json | Replica: 3.99 MB
bincode | Replica: 1.71 MB
zstd'd serde_json | Replica: 380.98 KB
zstd'd bincode | Replica: 268.81 KB
```

```py
# After
serde_json | Replica: 596.94 KB
bincode | Replica: 229.98 KB
zstd'd serde_json | Replica: 153.61 KB
zstd'd bincode | Replica: 128.68 KB
```