### PR TITLE
Rewrite the encoding scheme for integers

### DIFF
--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -164,25 +164,25 @@ mod serde {
         );
     }
 
-    // `cargo t --features=serde serde_automerge_json_sizes -- --nocapture`
+    // `cargo t --release --features=serde serde_automerge_json_sizes -- --nocapture`
     #[test]
     fn serde_automerge_json_sizes() {
         serde_sizes::<SerdeJson>(&traces::automerge());
     }
 
-    // `cargo t --features=serde serde_automerge_bincode_sizes -- --nocapture`
+    // `cargo t --release --features=serde serde_automerge_bincode_sizes -- --nocapture`
     #[test]
     fn serde_automerge_bincode_sizes() {
         serde_sizes::<Bincode>(&traces::automerge());
     }
 
-    // `cargo t --features=serde serde_automerge_compressed_json_sizes -- --nocapture`
+    // `cargo t --release --features=serde serde_automerge_compressed_json_sizes -- --nocapture`
     #[test]
     fn serde_automerge_compressed_json_sizes() {
         serde_sizes::<Zstd<SerdeJson>>(&traces::automerge());
     }
 
-    // `cargo t --features=serde serde_automerge_compressed_bincode_sizes -- --nocapture`
+    // `cargo t --release --features=serde serde_automerge_compressed_bincode_sizes -- --nocapture`
     #[test]
     fn serde_automerge_compressed_bincode_sizes() {
         serde_sizes::<Zstd<Bincode>>(&traces::automerge());


### PR DESCRIPTION
Rewrote the integer encoding/decoding logic. It now takes 1 byte to encode `0..63` and 2 to encode `64..2**15`. Integers `>=` than `2**15` are always encoded with a prefix byte that represents their length.

```py
# Before
serde_json | Replica: 596.94 KB
serde_json | Total insertions: 6.62 MB
serde_json | Total deletions: 4.04 MB

bincode | Replica: 229.98 KB
bincode | Total insertions: 3.96 MB
bincode | Total deletions: 2.16 MB

zstd'd serde_json | Replica: 153.61 KB
zstd'd serde_json | Total insertions: 7.36 MB
zstd'd serde_json | Total deletions: 4.61 MB

zstd'd bincode | Replica: 128.68 KB
zstd'd bincode | Total insertions: 5.52 MB
zstd'd bincode | Total deletions: 2.82 MB
```

```py
# After
serde_json | Replica: 553.96 KB
serde_json | Total insertions: 5.98 MB
serde_json | Total deletions: 3.78 MB

bincode | Replica: 163.05 KB
bincode | Total insertions: 3.24 MB
bincode | Total deletions: 1.81 MB

zstd'd serde_json | Replica: 156.95 KB
zstd'd serde_json | Total insertions: 7.08 MB
zstd'd serde_json | Total deletions: 4.42 MB

zstd'd bincode | Replica: 134.37 KB
zstd'd bincode | Total insertions: 4.81 MB
zstd'd bincode | Total deletions: 2.47 MB
```