### PR TITLE
Encode integers using LEB128

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,13 @@ features = ["serde"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-encode = ["dep:sha2"]
+encode = ["dep:sha2", "dep:varint-simd"]
 serde = ["encode", "dep:serde"]
 
 [dependencies]
 serde = { version = "1.0", optional = true }
 sha2 = { version = "0.10", optional = true }
+varint-simd = { version = "0.4", optional = true }
 
 [dev-dependencies]
 bincode = "1.3"

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -2,6 +2,8 @@ mod common;
 
 #[cfg(feature = "serde")]
 mod serde {
+    use std::io::{self, Write};
+
     use serde::de::DeserializeOwned;
     use serde::ser::Serialize;
     use traces::{ConcurrentTraceInfos, Crdt, Edit, SequentialTrace};
@@ -141,14 +143,22 @@ mod serde {
             }
         };
 
+        let mut stdout = io::stdout();
+
         let replica_size = E::encode(&replica.encode()).len();
 
-        println!("{} | Replica: {}", E::name(), printed_size(replica_size));
+        let _ = writeln!(
+            &mut stdout,
+            "{} | Replica: {}",
+            E::name(),
+            printed_size(replica_size)
+        );
 
         let total_insertions_size =
             insertions.iter().map(Vec::len).sum::<usize>();
 
-        println!(
+        let _ = writeln!(
+            &mut stdout,
             "{} | Total insertions: {}",
             E::name(),
             printed_size(total_insertions_size)
@@ -157,7 +167,8 @@ mod serde {
         let total_deletions_size =
             deletions.iter().map(Vec::len).sum::<usize>();
 
-        println!(
+        let _ = writeln!(
+            &mut stdout,
             "{} | Total deletions: {}",
             E::name(),
             printed_size(total_deletions_size)


### PR DESCRIPTION
Using LEB128 seems to bring a 0-10% reduction in message size compared to our own variable-length integer encoding algorithm.

Before:

```
bincode | Replica: 163.05 KB
bincode | Total insertions: 3.24 MB
bincode | Total deletions: 1.81 MB

serde_json | Replica: 553.96 KB
serde_json | Total insertions: 5.98 MB
serde_json | Total deletions: 3.78 MB

zstd'd bincode | Replica: 134.37 KB
zstd'd bincode | Total insertions: 4.81 MB
zstd'd bincode | Total deletions: 2.47 MB

zstd'd serde_json | Replica: 156.90 KB
zstd'd serde_json | Total insertions: 7.08 MB
zstd'd serde_json | Total deletions: 4.42 MB
```

After:

```
bincode | Replica: 160.76 KB
bincode | Total insertions: 3.14 MB
bincode | Total deletions: 1.74 MB

serde_json | Replica: 494.34 KB
serde_json | Total insertions: 5.39 MB
serde_json | Total deletions: 3.43 MB

zstd'd bincode | Replica: 133.02 KB
zstd'd bincode | Total insertions: 4.71 MB
zstd'd bincode | Total deletions: 2.40 MB

zstd'd serde_json | Replica: 146.91 KB
zstd'd serde_json | Total insertions: 6.63 MB
zstd'd serde_json | Total deletions: 4.09 MB
```